### PR TITLE
Rename glyphs

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -61,10 +61,10 @@ class FontProject:
                 printed_names.append('...')
             print('Found %s glyph names containing hyphens: %s' % (
                 num_names, ', '.join(printed_names)))
-            print('Replacing all hyphens with underscores.')
+            print('Replacing all hyphens with periods.')
 
         for old_name in names:
-            new_name = old_name.replace('-', '_')
+            new_name = old_name.replace('-', '.')
             text = text.replace(old_name, new_name)
         return text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-# for ufo2ft
-git+https://github.com/behdad/fonttools.git
-
 # for booleanOperations
 cython
 
 # direct dependencies
+git+https://github.com/behdad/fonttools.git
 git+https://github.com/googlei18n/cu2qu.git
 git+https://github.com/googlei18n/glyphs2ufo.git
 git+https://github.com/googlei18n/ufo2ft.git


### PR DESCRIPTION
This adds a glyph rename operation as the last compilation step in fontmake. I'm actually not sure if this is the best place for the production name generation logic. Maybe it should be in glyphsLib, and every glyph in the UFOs should have production name entries? Maybe the subset/rename stuff should all be in ufo2ft?

Related to https://github.com/googlei18n/glyphsLib/issues/12
cc @behdad @schriftgestalt