### PR TITLE
Revert "Add missing robofab dependency"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# for fontMath
-git+https://github.com/robofab-developers/robofab.git
-
 # for MutatorMath
 git+https://github.com/typesupply/fontMath.git@ufo3
 git+https://github.com/unified-font-object/ufoLib.git


### PR DESCRIPTION
This reverts commit 402e8f8ae59eae52ced388bed71e5c80fbe8c430.

Followup to typesupply/fontMath#25.