### PR TITLE
README.md: don't recommend using `sudo` to install fontmake and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,21 @@ together compile fonts from various sources (.glyphs, .ufo) into binaries (.otf,
 
 ### Install
 
+Create new virtual environment (optional, but *recommended*):
 ```bash
-sudo python -m pip install -r requirements.txt
-sudo python setup.py develop
+python -m pip install --user virtualenv  # install virtualenv if not available
+python -m virtualenv env  # create environment named 'env' in current folder
+source env/bin/activate  # activate the environment (run `deactivate` to exit)
+```
+
+Install fontmake's dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Install fontmake:
+```bash
+pip install -e .  # `-e` is for "editable" mode, only required for developers
 ```
 
 ### Run


### PR DESCRIPTION
Using `sudo` with `pip` is not good. The Linux or OSX's system python is part of the operating system and should not be modified by the users via external package managers like `pip`.

Users should be recommended to use pip's `--user` option, which installs in the user's site-packages, or better use `virtualenv`, which does not require admin privileges and provides isolation from the dependency hell.