### PR TITLE
Add option to keep overlaps

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -28,6 +28,8 @@ def main():
                         help='interpolate masters (Glyphs source only)')
     parser.add_argument('--mti-source')
     parser.add_argument('--use-afdko', action='store_true')
+    parser.add_argument('--keep-overlaps', dest="remove_overlaps",
+                        action='store_false')
     parser.add_argument('--timing', action='store_true')
     args = vars(parser.parse_args())
 

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -134,21 +134,23 @@ class FontProject:
                 print('>> Converting curves for ' + self._font_name(ufo))
                 font_to_quadratic(ufo, reverse_direction=True, dump_stats=True)
 
-    def build_otfs(self, ufos, **kwargs):
+    def build_otfs(self, ufos, remove_overlaps=True, **kwargs):
         """Build OpenType binaries with CFF outlines."""
 
         print('\n>> Building OTFs')
 
         self.decompose_glyphs(ufos)
-        self.remove_overlaps(ufos)
+        if remove_overlaps:
+            self.remove_overlaps(ufos)
         self.save_otfs(ufos, **kwargs)
 
-    def build_ttfs(self, ufos, **kwargs):
+    def build_ttfs(self, ufos, remove_overlaps=True, **kwargs):
         """Build OpenType binaries with TrueType outlines."""
 
         print('\n>> Building TTFs')
 
-        self.remove_overlaps(ufos)
+        if remove_overlaps:
+            self.remove_overlaps(ufos)
         self.convert_curves(ufos)
         self.save_otfs(ufos, ttf=True, **kwargs)
 


### PR DESCRIPTION
Some font source may already have removed overlap, or one may not want to remove overlaps. booleanOperations cannot yet remove overlap for quadratic curves: https://github.com/typemytype/booleanOperations/issues/26.