### PR TITLE
Add option to keep direction since default reverses contour direction

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -31,6 +31,9 @@ def main():
     parser.add_argument('--family-name', help='Family name to use for masters,'
                         ' and to filter output instances by')
     parser.add_argument('--use-afdko', action='store_true')
+    parser.add_argument('--keep-direction', dest="reverse_direction",
+                        action='store_false', help='Do not reverse contour '
+                        'direction when output is ttf or ttf-interpolatable')
     parser.add_argument('--keep-overlaps', dest="remove_overlaps",
                         action='store_false',
                         help='Do not remove any overlap.')

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -128,13 +128,15 @@ class FontProject:
             component.draw(pen)
 
     @timer()
-    def convert_curves(self, ufos, compatible=False):
+    def convert_curves(self, ufos, compatible=False, reverse_direction=True):
         if compatible:
-            fonts_to_quadratic(ufos, reverse_direction=True, dump_stats=True)
+            fonts_to_quadratic(ufos, reverse_direction=reverse_direction,
+                               dump_stats=True)
         else:
             for ufo in ufos:
                 print('>> Converting curves for ' + self._font_name(ufo))
-                font_to_quadratic(ufo, reverse_direction=True, dump_stats=True)
+                font_to_quadratic(ufo, reverse_direction=reverse_direction,
+                                  dump_stats=True)
 
     def build_otfs(self, ufos, remove_overlaps=True, **kwargs):
         """Build OpenType binaries with CFF outlines."""
@@ -144,6 +146,7 @@ class FontProject:
         self.decompose_glyphs(ufos)
         if remove_overlaps:
             self.remove_overlaps(ufos)
+        del kwargs['reverse_direction']
         self.save_otfs(ufos, **kwargs)
 
     def build_ttfs(self, ufos, remove_overlaps=True, **kwargs):
@@ -153,7 +156,8 @@ class FontProject:
 
         if remove_overlaps:
             self.remove_overlaps(ufos)
-        self.convert_curves(ufos)
+        reverse_direction = kwargs.pop('reverse_direction')
+        self.convert_curves(ufos, reverse_direction=reverse_direction)
         self.save_otfs(ufos, ttf=True, **kwargs)
 
     def build_interpolatable_ttfs(self, ufos, **kwargs):
@@ -161,7 +165,9 @@ class FontProject:
 
         print('\n>> Building interpolation-compatible TTFs')
 
-        self.convert_curves(ufos, compatible=True)
+        reverse_direction = kwargs.pop('reverse_direction')
+        self.convert_curves(ufos, compatible=True,
+                            reverse_direction=reverse_direction)
         self.save_otfs(ufos, ttf=True, interpolatable=True, **kwargs)
 
     @timer()


### PR DESCRIPTION
This can be used along with --keep-overlaps, in case the source already has the right contours.