### PR TITLE
Update glyphsLib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cython==0.24
 
 # direct dependencies
 git+https://github.com/googlei18n/cu2qu.git@c82b78b1b80a17c035420fcb08aeb3a844550da4
-git+https://github.com/googlei18n/glyphsLib.git@b8b247a4d9f101dddb04bacde730b5c8570aa881
+git+https://github.com/googlei18n/glyphsLib.git@729e05e4ac10ae509712f2e00a872a29fdbab505
 git+https://github.com/googlei18n/ufo2ft.git@c24f4eaae7472bb0f5dde7046d96768343d5a9fb
 git+https://github.com/LettError/MutatorMath.git@8af13c589f4ca7f5c4707dee481ce0ec17c01bd9
 git+https://github.com/typemytype/booleanOperations.git@e19f4405d51b21a4c205939ffb670f440f053c7e


### PR DESCRIPTION
This should fix parsing of Glyphs source with un-escaped unicode
characters.