### PR TITLE
avoid converting the curves twice with latest ufo2ft

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -199,7 +199,8 @@ class FontProject:
                 ufo, featureCompilerClass=fea_compiler,
                 mtiFeaFiles=mti_paths[name] if mti_paths is not None else None,
                 glyphOrder=ufo.lib[PUBLIC_PREFIX + 'glyphOrder'],
-                useProductionNames=use_production_names)
+                useProductionNames=use_production_names,
+                convertCubics=False)
             otf.save(otf_path)
 
             if subset:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ git+https://github.com/typesupply/fontMath.git@e96af7a672aa8173139952cf78405b6c4
 git+https://github.com/unified-font-object/ufoLib.git@d5514cc566080a2798614b9f9d413b755479dd88
 
 # for ufo2ft
-git+https://github.com/behdad/fonttools.git@384b050b080d4b2c534e838cd47a3dfc842665cb
+git+https://github.com/behdad/fonttools.git@efb8642366eef06ab482473793136ecba679f35a
 git+https://github.com/googlei18n/compreffor.git@628e625304bc901515ba24f0ffec9eb0033e9dd0
 
 # for booleanOperations

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cython==0.24
 # direct dependencies
 git+https://github.com/googlei18n/cu2qu.git@c82b78b1b80a17c035420fcb08aeb3a844550da4
 git+https://github.com/googlei18n/glyphsLib.git@729e05e4ac10ae509712f2e00a872a29fdbab505
-git+https://github.com/googlei18n/ufo2ft.git@c24f4eaae7472bb0f5dde7046d96768343d5a9fb
+git+https://github.com/googlei18n/ufo2ft.git@571b16406964805a904dc5b331b1ebfb9b38890a
 git+https://github.com/LettError/MutatorMath.git@8af13c589f4ca7f5c4707dee481ce0ec17c01bd9
 git+https://github.com/typemytype/booleanOperations.git@e19f4405d51b21a4c205939ffb670f440f053c7e
 git+https://github.com/typesupply/defcon.git@ad4d1d36f264e19c3a38a55a3489e33a4161873b


### PR DESCRIPTION
The current ufo2ft has a new `convertCubics=True` argument  which conflicts with fontmake, as the latter already calls `cu2qu.font[s]_to_quadratic` before passing the font to ufo2ft.
So fontmake needs to set that to False.


