### PR TITLE
do not always run the fonttools subsetter

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -41,15 +41,20 @@ def main():
     parser.add_argument('--keep-overlaps', dest="remove_overlaps",
                         action='store_false',
                         help='Do not remove any overlap.')
-    group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument('--production-names', dest='use_production_names',
-                       action='store_true', help='Rename glyphs with '
-                       'production names if available otherwise use uninames.')
-    group.add_argument('--no-production-names', dest='use_production_names',
-                       action='store_false',
-                       help='Do not rename glyphs with production names. '
-                       'Keeps original glyph names')
-    parser.set_defaults(use_production_names=None)
+    group1 = parser.add_mutually_exclusive_group(required=False)
+    group1.add_argument('--production-names', dest='use_production_names',
+                        action='store_true', help='Rename glyphs with '
+                        'production names if available otherwise use uninames.')
+    group1.add_argument('--no-production-names', dest='use_production_names',
+                        action='store_false',
+                        help='Do not rename glyphs with production names. '
+                        'Keeps original glyph names')
+    group2 = parser.add_mutually_exclusive_group(required=False)
+    group2.add_argument('--subset', dest='subset',
+                        action='store_true', help='Subset font using export '
+                        'flags set by glyphsLib')
+    group2.add_argument('--no-subset', dest='subset', action='store_false')
+    parser.set_defaults(use_production_names=None, subset=None)
     parser.add_argument('--timing', action='store_true')
     args = vars(parser.parse_args())
 

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -46,9 +46,7 @@ def main():
                         action='store_true', help='Rename glyphs with '
                         'production names if available otherwise use uninames.')
     group1.add_argument('--no-production-names', dest='use_production_names',
-                        action='store_false',
-                        help='Do not rename glyphs with production names. '
-                        'Keeps original glyph names')
+                        action='store_false')
     group2 = parser.add_mutually_exclusive_group(required=False)
     group2.add_argument('--subset', dest='subset',
                         action='store_true', help='Subset font using export '

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -175,7 +175,7 @@ class FontProject:
     @timer()
     def save_otfs(
             self, ufos, ttf=False, interpolatable=False, mti_paths=None,
-            is_instance=False, use_afdko=False, autohint=None, subset=True,
+            is_instance=False, use_afdko=False, autohint=None, subset=None,
             use_production_names=None):
         """Write OpenType binaries."""
 
@@ -199,6 +199,8 @@ class FontProject:
                 convertCubics=False)
             otf.save(otf_path)
 
+            if subset is None:
+                subset = (GLYPHS_PREFIX + 'Keep Glyphs') in ufo.lib
             if subset:
                 self.subset_otf_from_ufo(otf_path, ufo)
 

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -200,7 +200,10 @@ class FontProject:
             otf.save(otf_path)
 
             if subset is None:
-                subset = (GLYPHS_PREFIX + 'Keep Glyphs') in ufo.lib
+                export_key = GLYPHS_PREFIX + 'Glyphs.Export'
+                subset = ((GLYPHS_PREFIX + 'Keep Glyphs') in ufo.lib or
+                          any(glyph.lib.get(export_key, True) is False
+                              for glyph in ufo))
             if subset:
                 self.subset_otf_from_ufo(otf_path, ufo)
 


### PR DESCRIPTION
`save_otfs` method has a `subset` keyword argument which defaults to `True`, without a command line option to disable it.
The fonttools Subsetter is called on the generated font, even if the input UFO does not have any `com.schriftgestaltung.Keep Glyphs` key in the `lib.plist`, nor any of the .glif libs have `com.schriftgestaltung.Glyphs.Export` set to False.

This PR set the default value of 'subset' argument to `None`, and adds two command line options `--subset` and `--no-subset`.

`None` means run the subsetter only if the "Keep Glyphs" list is present in the lib.plist.
