### PR TITLE
dev_requirements.txt: install all dependencies from HEAD

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,18 @@
+# for MutatorMath
+-e git+https://github.com/typesupply/fontMath.git@ufo3#egg=fontMath
+-e git+https://github.com/unified-font-object/ufoLib.git#egg=ufoLib
+
+# for ufo2ft
+-e git+https://github.com/behdad/fonttools.git#egg=fonttools
+-e git+https://github.com/googlei18n/compreffor.git#egg=compreffor
+
+# for booleanOperations
+cython==0.24
+
+# direct dependencies
+-e git+https://github.com/googlei18n/cu2qu.git#egg=cu2qu
+-e git+https://github.com/googlei18n/glyphsLib.git#egg=glyphsLib
+-e git+https://github.com/googlei18n/ufo2ft.git#egg=ufo2ft
+-e git+https://github.com/LettError/MutatorMath.git#egg=MutatorMath
+-e git+https://github.com/typemytype/booleanOperations.git#egg=booleanOperations
+-e git+https://github.com/typesupply/defcon.git#egg=defcon


### PR DESCRIPTION
It could be used as a shorthand for checking if anything breaks when some dependency gets updated, before modifying the actual "requirements.txt" file (which must keep pinned-down versions).
