### PR TITLE
Windows: fix "IOError: [Errno 13] Permission denied" when re-opening named temporary file

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -28,7 +28,7 @@ from cu2qu.pens import ReverseContourPen
 from cu2qu.ufo import font_to_quadratic, fonts_to_quadratic
 from defcon import Font
 from fontTools import subset
-from fontTools.misc.py23 import tobytes
+from fontTools.misc.py23 import tobytes, UnicodeIO
 from fontTools.misc.loggingTools import configLogger, Timer
 from fontTools.misc.transform import Transform
 from fontTools.pens.transformPen import TransformPen
@@ -253,21 +253,18 @@ class FontProject:
         subset.save_font(font, otf_path, opt)
 
     def run_from_glyphs(
-            self, glyphs_path, preprocess=True, interpolate=False,
+            self, glyphs_file, preprocess=True, interpolate=False,
             masters_as_instances=False, family_name=None, **kwargs):
         """Run toolchain from Glyphs source to OpenType binaries."""
 
         if preprocess:
             print('>> Checking Glyphs source for illegal glyph names')
-            glyphs_source = self.preprocess(glyphs_path)
-            tmp_glyphs_file = tempfile.NamedTemporaryFile()
-            glyphs_path = tmp_glyphs_file.name
-            tmp_glyphs_file.write(tobytes(glyphs_source, encoding='utf-8'))
-            tmp_glyphs_file.seek(0)
+            glyphs_source = self.preprocess(glyphs_file)
+            glyphs_file = UnicodeIO(glyphs_source)
 
         print('>> Building UFOs from Glyphs source')
         ufos = self.build_ufos(
-            glyphs_path, interpolate, masters_as_instances, family_name)
+            glyphs_file, interpolate, masters_as_instances, family_name)
         self.run_from_ufos(
             ufos, is_instance=(interpolate or masters_as_instances), **kwargs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cython==0.24
 
 # direct dependencies
 git+https://github.com/googlei18n/cu2qu.git@c82b78b1b80a17c035420fcb08aeb3a844550da4
-git+https://github.com/googlei18n/glyphsLib.git@0630c672df3298fd77b4df66ddbf2e77c1fb00ed
+git+https://github.com/googlei18n/glyphsLib.git@dd555cc236bd240c94ec4194370fc44e4d10051a
 git+https://github.com/googlei18n/ufo2ft.git@571b16406964805a904dc5b331b1ebfb9b38890a
 git+https://github.com/LettError/MutatorMath.git@8af13c589f4ca7f5c4707dee481ce0ec17c01bd9
 git+https://github.com/typemytype/booleanOperations.git@e19f4405d51b21a4c205939ffb670f440f053c7e


### PR DESCRIPTION
on Windows we need to close the temporary file, before we can re-open it by the name... Which basically makes the whole use of NamedTemporaryFile almost pointless...

See https://bugs.python.org/issue14243

Anyway, this fixes it for now.
If we find we need to do this often, we can wrap the `try... finally` in a custom @contextmanager that does the cleanup on exit.