### PR TITLE
[ttfautohint] run with default options if --autohint is specified without argument

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -29,7 +29,7 @@ def main():
                              'sources only)')
     parser.add_argument('-mi', '--masters-as-instances', action='store_true',
                         help='treat masters as instances')
-    parser.add_argument('-a', '--autohint', nargs='?',
+    parser.add_argument('-a', '--autohint', nargs='?', const="",
                         help='can provide arguments to ttfautohint, quoted')
     parser.add_argument('--mti-source')
     parser.add_argument('--family-name', help='Family name to use for masters,'


### PR DESCRIPTION
The `--autohint` option uses `nargs=?` which allows to specify the option without argument (or with 1 argument), defaulting to `None`.
However, in `save_otfs`, the ttfautohint subprocess is called only if the `autohint` keyword argument is not None.

I would expect that calling fontmake with `-a` would run ttfautohint using the latter's default options, but at the moment it is simply ignored.

Either we make `-a` option require an argument and raise if one is not provided (which is the argparse default behavior, without `nargs=?`) or we use `const` to use a constant empty string when the option is provided without argument following it, which is what I do here: 

https://docs.python.org/3/library/argparse.html#const
