### PR TITLE
add --subroutinize/--no-subroutinize options

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -52,7 +52,13 @@ def main():
                         action='store_true', help='Subset font using export '
                         'flags set by glyphsLib')
     group2.add_argument('--no-subset', dest='subset', action='store_false')
-    parser.set_defaults(use_production_names=None, subset=None)
+    group3 = parser.add_mutually_exclusive_group(required=False)
+    group3.add_argument('-s', '--subroutinize', action='store_true',
+                        help='Optimize CFF table using compreffor')
+    group3.add_argument('-S', '--no-subroutinize', dest='subroutinize',
+                        action='store_false')
+    parser.set_defaults(use_production_names=None, subset=None,
+                        subroutinize=None)
     parser.add_argument('--timing', action='store_true')
     args = vars(parser.parse_args())
 

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -179,7 +179,7 @@ class FontProject:
     def save_otfs(
             self, ufos, ttf=False, interpolatable=False, mti_paths=None,
             is_instance=False, use_afdko=False, autohint=None, subset=None,
-            use_production_names=None):
+            use_production_names=None, subroutinize=None):
         """Write OpenType binaries."""
 
         ext = 'ttf' if ttf else 'otf'
@@ -199,7 +199,7 @@ class FontProject:
                 mtiFeaFiles=mti_paths[name] if mti_paths is not None else None,
                 glyphOrder=ufo.lib[PUBLIC_PREFIX + 'glyphOrder'],
                 useProductionNames=use_production_names,
-                convertCubics=False)
+                convertCubics=False, optimizeCff=subroutinize)
             otf.save(otf_path)
 
             if subset is None:


### PR DESCRIPTION
This PR depends on https://github.com/googlei18n/ufo2ft/pull/61

If that's merged, the fontmake default behavior would remain the same as the current one: i.e., always run compreffor if a CFF table is present.

But In addition, fontmake could gently skip running compreffor when the latter is not installed (it's still a bit tricky to compile compreffor on Windows, but I'm working on providing pre-compiled wheels for that).

On the other hand, if the '-s' ('--subroutinize') option is explicitly provided, then ufo2ft raises ImportError when compreffor is not installed.

Finally, when the '-S' ('--no-subroutinize') option is provided, fontmake tells ufo2ft to skip compreffor altogether, whether it's installed or not.

Note that on makeotf subroutinization is optional, not default.
I'm ok with leaving the current fontmake's default -- as long as it doesn't force you to install 10GB Visual Studio and monkeypatch setuptools...