### PR TITLE
Only use single-letter short options (no -mi)

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -27,7 +27,7 @@ def main():
     parser.add_argument('-i', '--interpolate', action='store_true',
                         help='interpolate masters (for Glyphs or MutatorMath '
                              'sources only)')
-    parser.add_argument('-mi', '--masters-as-instances', action='store_true',
+    parser.add_argument('-M', '--masters-as-instances', action='store_true',
                         help='treat masters as instances')
     parser.add_argument('-a', '--autohint', nargs='?', const="",
                         help='can provide arguments to ttfautohint, quoted')


### PR DESCRIPTION
Should resolve https://github.com/googlei18n/fontmake/issues/126