### PR TITLE
requirements.txt: update booleanOperations

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,9 +6,6 @@
 -e git+https://github.com/behdad/fonttools.git#egg=fonttools
 -e git+https://github.com/googlei18n/compreffor.git#egg=compreffor
 
-# for booleanOperations
-cython>=0.24
-
 # direct dependencies
 -e git+https://github.com/googlei18n/cu2qu.git#egg=cu2qu
 -e git+https://github.com/googlei18n/glyphsLib.git#egg=glyphsLib

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ git+https://github.com/googlei18n/cu2qu.git@ab3c0f82e60de746bafd2e3a9fab3a176840
 git+https://github.com/googlei18n/glyphsLib.git@5dc523f7472a9fcd4aade865a2c5f84bb272fcc6
 git+https://github.com/googlei18n/ufo2ft.git@c8826564103f0cf3c57cdd51e453e765528d12ed
 git+https://github.com/LettError/MutatorMath.git@652b075cc1cbc0b96ad6025906970e13bc77264e
---find-links https://github.com/typemytype/booleanOperations/releases
-booleanOperations==0.4
 git+https://github.com/typesupply/defcon.git@a70a27b7607a92e8b9d7181e6c58061547d19942
+booleanOperations==0.5.1


### PR DESCRIPTION
As of version 0.5.1, booleanOperations is published on [PyPI](
https://pypi.org/project/booleanOperations) so one can `pip install booleanOperations`.