### PR TITLE
Use logging module

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -87,9 +87,11 @@ def main():
                         subroutinize=True)
 
     parser.add_argument('--timing', action='store_true')
+    parser.add_argument('--verbosity', default='INFO')
     args = vars(parser.parse_args())
 
-    project = FontProject(timing=args.pop('timing'))
+    project = FontProject(timing=args.pop('timing'),
+                          verbosity=args.pop('verbosity'))
 
     glyphs_path = args.pop('glyphs_path')
     ufo_paths = args.pop('ufo_paths')


### PR DESCRIPTION
This allows the user to specify whether they want to see the build status messages or not via a --verbosity flag.

It has the side effect, however, of printing info from dependencies. In the case of MutatorMath, which otherwise runs silently for a long time, this isn't necessarily a bad thing. Though in some cases (e.g. fontTools' subsetter) the info messages can be a bit noisy.

We probably want to do something similar for glyphsLib, ufo2ft, and cu2qu.

@marekjez86: this should radically change the format of fontmake console output, but may allow us to build LGC fonts on Travis. (At least, it shouldn't time out due to MutatorMath silence.  The overall process may still take too long.)