### PR TITLE
Fix for verbose KeyError

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -91,7 +91,7 @@ def main():
     args = vars(parser.parse_args())
 
     project = FontProject(timing=args.pop('timing'),
-                          verbosity=args.pop('verbosity'))
+                          verbosity=args.pop('verbose'))
 
     glyphs_path = args.pop('glyphs_path')
     ufo_paths = args.pop('ufo_paths')


### PR DESCRIPTION
On a clean install, when I run anything, it throws a `KeyError: 'verbosity'`. For example `fontmake -o ttf-interpolatable -m myfont.designspace`, I get this:

<img width="1044" alt="screen shot 2016-10-13 at 1 26 14 pm" src="https://cloud.githubusercontent.com/assets/980360/19365678/b1469416-9148-11e6-9255-342a3e73aab5.png">

It seems like there was a leftover `verbosity` reference that needed to be renamed, from this commit: https://github.com/googlei18n/fontmake/commit/bfc7ef692937020a13f3995c1462f6c2b1fc60df

I'm not sure if this solution is the best fix, or if there are more references, but it works for me now.