### PR TITLE
font_project.py: log the font/glyph names when booleanOperations fail

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -95,15 +95,20 @@ class FontProject:
     @timer()
     def remove_overlaps(self, ufos):
         """Remove overlaps in UFOs' glyphs' contours."""
-        from booleanOperations import BooleanOperationManager
+        from booleanOperations import union, BooleanOperationsError
 
-        manager = BooleanOperationManager()
         for ufo in ufos:
-            self.info('Removing overlaps for ' + self._font_name(ufo))
+            font_name = self._font_name(ufo)
+            self.info('Removing overlaps for ' + font_name)
             for glyph in ufo:
                 contours = list(glyph)
                 glyph.clearContours()
-                manager.union(contours, glyph.getPointPen())
+                try:
+                    union(contours, glyph.getPointPen())
+                except BooleanOperationsError:
+                    self.logger.error("Failed to remove overlaps for %s: %r",
+                                      font_name, glyph.name)
+                    raise
 
     @timer()
     def decompose_glyphs(self, ufos):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ git+https://github.com/googlei18n/glyphsLib.git@ee916ba6162396ef4a3ae68b5ea0b7be
 git+https://github.com/googlei18n/ufo2ft.git@c8826564103f0cf3c57cdd51e453e765528d12ed
 git+https://github.com/LettError/MutatorMath.git@652b075cc1cbc0b96ad6025906970e13bc77264e
 git+https://github.com/typesupply/defcon.git@a70a27b7607a92e8b9d7181e6c58061547d19942
-booleanOperations==0.5.1
+git+https://github.com/typemytype/booleanOperations.git@a7113f81408cf89887882a8b9b04596a01ad38c8


### PR DESCRIPTION
Sometimes booleanOperations may fail because the input contours are invalid for clipping (e.g. see https://github.com/googlei18n/fontmake/issues/161)

With https://github.com/typemytype/booleanOperations/pull/37, we can catch a `BooleanOperationsError`, and let users know where to find the invalid path, so they can fix it.

Also, we can use `booleanOperations.union` function directly, instead of instantiating a `BooleanOperationManager` instance, as the `union` method is static anyway.

This PR depends on the above PR being merged first.