### PR TITLE
follow up on PR #200

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 dist
+src
 *.pyc
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build
 dist
-src
 *.pyc
 *.egg-info/

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -26,16 +26,24 @@ class PyClassType(object):
         self.class_name = class_name
 
     def __call__(self, module_name):
+        import importlib
+        import inspect
+
         try:
-            import importlib
             mod = importlib.import_module(module_name)
         except ImportError:
             raise ArgumentTypeError("No module named %r" % module_name)
-        else:
-            try:
-                return getattr(mod, self.class_name)
-            except AttributeError as e:
-                raise ArgumentTypeError(e)
+
+        try:
+            klass = getattr(mod, self.class_name)
+        except AttributeError as e:
+            raise ArgumentTypeError("Module %r has no attribute %r"
+                                    % (module_name, self.class_name))
+
+        if not inspect.isclass(klass):
+            raise ArgumentTypeError("%r is not a class: %r"
+                                    % (self.class_name, type(klass)))
+        return klass
 
 
 def exclude_args(parser, args, excluded_args, source_name):

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -46,7 +46,7 @@ def exclude_args(parser, args, excluded_args, source_name):
         del args[excluded]
 
 
-def main():
+def main(args=None):
     parser = ArgumentParser()
     inputGroup = parser.add_argument_group(
         title='Input arguments',
@@ -149,7 +149,7 @@ def main():
         choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
         help='Configure the logger verbosity level. Choose between: '
              '%(choices)s. Default: INFO')
-    args = vars(parser.parse_args())
+    args = vars(parser.parse_args(args))
 
     project = FontProject(timing=args.pop('timing'),
                           verbose=args.pop('verbose'))

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -43,7 +43,8 @@ def main():
         help='Interpolate layout tables from compiled master binaries. '
              'Requires Glyphs or MutatorMath source.')
     parser.add_argument(
-        '--use-afdko', action='store_true')
+        '--use-afdko', action='store_true', 
+        help='Use makeOTF instead of feaLib to compile features.')
 
     parser.add_argument(
         '-a', '--autohint', nargs='?', const='',
@@ -82,6 +83,12 @@ def main():
         '-e', '--conversion-error', type=float, default=None, metavar='ERROR',
         help='Maximum approximation error for cubic to quadratic conversion '
              'measured in EM')
+    parser.add_argument(
+        '--use-kern-writer', dest='kern_writer', action='store', default=None,
+        help='Use custom module with KernFeatureWriter Python class.')
+    parser.add_argument(
+        '--use-mark-writer', dest='mark_writer', action='store', default=None,
+        help='Use custom module with MarkFeatureWriter Python class.')
 
     parser.set_defaults(use_production_names=None, subset=None,
                         subroutinize=True)

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -216,7 +216,8 @@ class FontProject:
             self, ufos, ttf=False, is_instance=False, interpolatable=False,
             mti_paths=None, use_afdko=False, autohint=None, subset=None,
             use_production_names=None, subroutinize=False,
-            interpolate_layout_from=None, kern_writer=None, mark_writer=None):
+            interpolate_layout_from=None, kern_writer_class=None,
+            mark_writer_class=None):
         """Build OpenType binaries from UFOs.
 
         Args:
@@ -237,37 +238,23 @@ class FontProject:
             subroutinize: If True, subroutinize CFF outlines in output.
             interpolate_layout_from: A designspace path to give varLib for
                 interpolating layout tables to use in output.
-            kern_writer: name of a Python module containing a KernFeatureWriter
-                class, overrides the use of that built into ufo2ft
-            mark_writer: name of a Python module containing a MarkFeatureWriter
-                class, overrides the use of that built into ufo2ft 
+            kern_writer_class: Class overriding ufo2ft's KernFeatureWriter.
+            mark_writer_class: Class overriding ufo2ft's MarkFeatureWriter.
         """
 
         ext = 'ttf' if ttf else 'otf'
         fea_compiler = FDKFeatureCompiler if use_afdko else FeatureOTFCompiler
         otf_compiler = compileTTF if ttf else compileOTF
 
-        if kern_writer: 
-            try: 
-                import importlib
-                kernWriterMod = importlib.import_module(kern_writer)
-                kernWriter = kernWriterMod.KernFeatureWriter
-            except ImportError: 
-                kernWriter = KernFeatureWriter
-                self.logger.warning("Cannot use custom kern_writer, using default")
-        else: 
-            kernWriter = KernFeatureWriter
+        if kern_writer_class is None:
+            kern_writer_class = KernFeatureWriter
+        else:
+            self.info("Using %r" % kern_writer_class.__module__)
 
-        if mark_writer: 
-            try: 
-                import importlib
-                markWriterMod = importlib.import_module(mark_writer)
-                markWriter = markWriterMod.MarkFeatureWriter
-            except ImportError: 
-                markWriter = MarkFeatureWriter
-                self.logger.warning("Cannot use custom mark_writer, using default")
-        else: 
-            markWriter = MarkFeatureWriter
+        if mark_writer_class is None:
+            mark_writer_class = MarkFeatureWriter
+        else:
+            self.info("Using %r" % mark_writer_class.__module__)
 
         if interpolate_layout_from is not None:
             master_locations, instance_locations = self._designspace_locations(
@@ -287,7 +274,7 @@ class FontProject:
             otf = otf_compiler(
                 ufo, featureCompilerClass=fea_compiler,
                 mtiFeaFiles=mti_paths[name] if mti_paths is not None else None,
-                kernWriter=kernWriter, markWriter=markWriter,
+                kernWriter=kern_writer_class, markWriter=mark_writer_class,
                 glyphOrder=ufo.lib.get(PUBLIC_PREFIX + 'glyphOrder'),
                 useProductionNames=use_production_names,
                 convertCubics=False, optimizeCff=subroutinize)


### PR DESCRIPTION
hey Adam @twardoch 
I reviewed your PR #200 and added a few commits on top of it.

- I renamed the options to `--kern-writer-module` and `--mark-writer-module`; I think it's better as they take a module name argument, while `--use-...` seems to imply a boolean value.

- the argument parser passes the class objects themselves rather than the module names; this also gives the chance to raise a parser.error when the module can't be imported or does not contain a class with the expected name. I think it's more reasonable to raise here, instead of just log a warning.

- I kept the grouping of the arguments, and only made cosmetic changes here and there.

Please take a look, thanks.