### PR TITLE
clarify that only 'mixed' glyphs are decomposed for TTFs

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -117,7 +117,7 @@ class FontProject:
         for ufo in ufos:
             logger.info('Decomposing glyphs for ' + self._font_name(ufo))
             for glyph in ufo:
-                if not glyph_filter(glyph):
+                if not glyph.components or not glyph_filter(glyph):
                     continue
                 self._deep_copy_contours(ufo, glyph, glyph, Transform())
                 glyph.clearComponents()

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -173,8 +173,10 @@ class FontProject:
 
         logger.info('Building TTFs')
 
-        # decompose glyphs with contours, since they're decomposed anyways when
-        # compiled into glyf tables
+        # decompose glyphs with mixed contours and components, since they're
+        # decomposed anyways when compiled into glyf tables.
+        # NOTE: bool(glyph) is True when len(glyph) != 0, i.e. if the glyph
+        # instance has any contours.
         self.decompose_glyphs(ufos, glyph_filter=lambda g: g)
         if remove_overlaps:
             self.remove_overlaps(ufos)


### PR DESCRIPTION
I was a bit confused by the `glyph_filter: lambda g: g` in this commit
https://github.com/googlei18n/fontmake/commit/a858bff08f1ac5847c80dad291be81508835125a#diff-77503f3639ebd287f468b3d480600aa9R178

until I realised that a Defcon Glyph object returns True with `bool(glyph)` if it contains any contours, or False otherwise.

I presume this works because it implements some of the built-in list methods (`__len__`, `__getitem__`, etc); however I don't see `__bool__` or `__nonzero__` anywhere in:
https://github.com/typesupply/defcon/blob/master/Lib/defcon/objects/glyph.py

Anyway, a test like `if not glyph: continue` looks a bit obscure to me when used on glyph objects, which do work like lists but are not quite lists.
I think it's clearer if we instead check the `len(glyph)`.

Also, I think that a method called `decompose_glyphs` should always skip glyphs which do not have any component to decompose; I don't see the reason to call `_deep_copy_contours` or `glyph.clearComponents` if a glyph has no component at all, as they won't do anything.