### PR TITLE
make interpolate/variable mutually exclusive; save VF to "variable_ttf"

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -161,12 +161,21 @@ def main(args=None):
              '%(choices)s. Default: INFO')
     args = vars(parser.parse_args(args))
 
-    project = FontProject(timing=args.pop('timing'),
-                          verbose=args.pop('verbose'))
-
     glyphs_path = args.pop('glyphs_path')
     ufo_paths = args.pop('ufo_paths')
     designspace_path = args.pop('mm_designspace')
+
+    if 'variable' in args['output']:
+        if not (glyphs_path or designspace_path):
+            parser.error(
+                'Glyphs or designspace source required for variable font')
+        if args['interpolate']:
+            parser.error(
+                '"interpolate" argument invalid for variable font')
+
+    project = FontProject(timing=args.pop('timing'),
+                          verbose=args.pop('verbose'))
+
     if glyphs_path:
         project.run_from_glyphs(glyphs_path, **args)
         return

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -169,9 +169,11 @@ def main(args=None):
         if not (glyphs_path or designspace_path):
             parser.error(
                 'Glyphs or designspace source required for variable font')
-        if args['interpolate']:
-            parser.error(
-                '"interpolate" argument invalid for variable font')
+        for argname in ('interpolate', 'masters_as_instances',
+                        'interpolate_binary_layout'):
+            if args[argname]:
+                parser.error('--%s option invalid for variable font'
+                             % argname.replace("_", "-"))
 
     project = FontProject(timing=args.pop('timing'),
                           verbose=args.pop('verbose'))

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -356,19 +356,27 @@ class FontProject(object):
 
         Args:
             designspace_path: Path to designspace document.
-            interpolate: If True output instance fonts, otherwise just masters
-                (only valid for non-variable output).
+            interpolate: If True output instance fonts, otherwise just masters.
             masters_as_instances: If True, output master fonts as instances.
             instance_data: Data to be applied to instance UFOs, as returned from
                 glyphsLib's parsing function.
             interpolate_binary_layout: Interpolate layout tables from compiled
                 master binaries.
             kwargs: Arguments passed along to run_from_ufos.
+
+        Raises:
+            TypeError: "variable" output is incompatible with arguments
+                "interpolate", "masters_as_instances", "instance_data" and
+                "interpolate_binary_layout".
         """
 
-        if interpolate and "variable" in kwargs.get("output", ()):
-            raise TypeError(
-                '"interpolate" argument incompatible with "variable" output')
+        if "variable" in kwargs.get("output", ()):
+            for argname in ("interpolate", "masters_as_instances",
+                            "instance_data", "interpolate_binary_layout"):
+                if locals()[argname]:
+                    raise TypeError(
+                        '"%s" argument incompatible with "variable" output'
+                        % argname)
 
         from glyphsLib.interpolation import apply_instance_data
         from mutatorMath.ufo import build as build_designspace

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -20,8 +20,12 @@ import glob
 import logging
 import math
 import os
-import plistlib
 import tempfile
+try:
+    from plistlib import load as readPlist  # PY3
+except ImportError:
+    from plistlib import readPlist  # PY2
+
 
 from cu2qu.pens import ReverseContourPen
 from cu2qu.ufo import font_to_quadratic, fonts_to_quadratic
@@ -430,7 +434,8 @@ class FontProject(object):
         mti_paths = None
         if mti_source:
             mti_paths = {}
-            mti_paths = plistlib.readPlist(mti_source)
+            with open(mti_source, 'rb') as mti_file:
+                mti_paths = readPlist(mti_file)
             src_dir = os.path.dirname(mti_source)
             for paths in mti_paths.values():
                 for tag in paths.keys():

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -21,15 +21,13 @@ import logging
 import math
 import os
 import plistlib
-import re
 import tempfile
-from io import open
 
 from cu2qu.pens import ReverseContourPen
 from cu2qu.ufo import font_to_quadratic, fonts_to_quadratic
 from defcon import Font
 from fontTools import subset
-from fontTools.misc.py23 import tobytes, UnicodeIO, basestring
+from fontTools.misc.py23 import tobytes, basestring
 from fontTools.misc.loggingTools import configLogger, Timer
 from fontTools.misc.transform import Transform
 from fontTools.pens.transformPen import TransformPen

--- a/test/test_arguments.py
+++ b/test/test_arguments.py
@@ -75,10 +75,10 @@ class TestOutputFileName(unittest.TestCase):
         project = FontProject()
         mock_designspace_locations.return_value = {'master1': 'location1'}, None
         mock_varLib_build.return_value = TTFont(), None, None
-        project.build_variable_font('path/to/designspace.designspace', True, False)
+        project.build_variable_font('path/to/designspace.designspace')
         self.assertTrue(mock_TTFont_save.called)
         self.assertTrue(mock_TTFont_save.call_count == 1)
-        self.assertEqual(mock_TTFont_save.call_args, mock.call('instance_ttf_variable/designspace-VF.ttf'))
+        self.assertEqual(mock_TTFont_save.call_args, mock.call('variable_ttf/designspace-VF.ttf'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a follow-up on PR #266.

The `-i/--interpolate` option is used to make instance UFOs with MutatorMath and shouldn't be used along with `-o variable` output; `fontTools.varLib` expects interpolatable _master_ TTFs (plus designspace), not _instances_.

Therefore, for the `build_variable_font` function, the argument `is_instance` or `interpolatable` don't make any sense and I removed them.

I also changed the default folder where variable fonts gets generated to "variable_ttf".
In the previous PR #266, @zjusbo used "master_ttf_variable", but I believe neither the 'master' nor 'instance' attributes qualify really well a variable font, which is... both!

Finally, since when generating a variable font we require a designspace file (or a glyphs file from which we generate a designspace file), it makes sense to stop earlier (at the argument parsing step), instead of failing much later on.