### PR TITLE
update fontmake to use the latest ufo2ft v0.4.0 API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools==3.8.0
+fonttools==3.9.0
 cu2qu==1.1.1
 glyphsLib==1.5.2
 ufo2ft==0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ cu2qu==1.1.1
 glyphsLib==1.5.2
 ufo2ft==0.3.4
 MutatorMath==2.0.2
-defcon==0.2.2
+defcon==0.2.4
 booleanOperations==0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fonttools==3.9.0
 cu2qu==1.1.1
 glyphsLib==1.5.2
-ufo2ft==0.3.4
+ufo2ft==0.4.0
 MutatorMath==2.0.2
 defcon==0.2.4
 booleanOperations==0.6.4

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "fonttools>=3.9.0",
         "cu2qu>=1.1.1",
         "glyphsLib>=1.5.2",
-        "ufo2ft>=0.3.4",
+        "ufo2ft>=0.4.0",
         "MutatorMath>=2.0.2",
         "defcon>=0.2.4",
         "booleanOperations>=0.6.4",

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,12 @@ setup(
         ]
     },
     install_requires=[
-        "fonttools>=3.7.2",
+        "fonttools>=3.9.0",
         "cu2qu>=1.1.1",
-        "glyphsLib>=1.5.1",
+        "glyphsLib>=1.5.2",
         "ufo2ft>=0.3.4",
         "MutatorMath>=2.0.2",
-        "defcon>=0.2.1",
+        "defcon>=0.2.4",
         "booleanOperations>=0.6.4",
     ],
     classifiers=[


### PR DESCRIPTION
ufo2ft v0.4.0 changed the names of some modules, classes and arguments.
I adapted fontmake to use the current names.

Full changelog:
https://github.com/googlei18n/ufo2ft/releases/tag/v0.4.0