### PR TITLE
[travis] update pip to install from precompiled manylinux1 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.5"
 
 install:
+  - pip install --upgrade pip
   - pip install -r test_requirements.txt .
 
 script:


### PR DESCRIPTION
The pip version installed by default on the Travis python is too old and does not support installing from binary 'manylinux1' wheels.
Upgrading pip should speed up the CI builds, as we can install pyclipper and compreffor from the pre-compiled wheel packages.