### PR TITLE
Clean up workflow for Monotype feature files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fonttools==3.10.0
 cu2qu==1.1.1
 glyphsLib==1.6.0
-ufo2ft==0.4.2
+ufo2ft==0.5.0
 MutatorMath==2.0.4
 defcon==0.3.2
 booleanOperations==0.7.0

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ setup(
         "fonttools>=3.10.0",
         "cu2qu>=1.1.1",
         "glyphsLib>=1.6.0",
-        "ufo2ft>=0.4.2",
+        "ufo2ft>=0.5.0",
         "MutatorMath>=2.0.4",
         "defcon>=0.3.1",
         "booleanOperations>=0.7.0",


### PR DESCRIPTION
Instead of injecting the Monotype feature files late into the
pipeline, we now embed them into UFO files so that the UFOs are fully
self-contained. This change also cleans up the way how the data
gets embedded into the UFO; instead of changing files underneath
defcon, fontmake now calls the defcon data APIs.

The handling of Monotype feature files was added to ufo2ft in
version 0.4.3, so fontmake now requires that version.

https://github.com/googlei18n/fontmake/issues/289