### PR TITLE
Update glyphsLib from 1.6.0 to 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fonttools==3.10.0
 cu2qu==1.1.1
-glyphsLib==1.6.0
+glyphsLib==1.7.0
 ufo2ft==0.5.0
 MutatorMath==2.0.4
 defcon==0.3.2

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ setup(
     install_requires=[
         "fonttools>=3.10.0",
         "cu2qu>=1.1.1",
-        "glyphsLib>=1.6.0",
+        "glyphsLib>=1.7.0",
         "ufo2ft>=0.5.0",
         "MutatorMath>=2.0.4",
         "defcon>=0.3.1",


### PR DESCRIPTION
Notable changes:

* designspace documents now contain `<axes>` for variation fonts

* the value range of the width axis now conforms to the OpenType spec

* font instances can now specify custom PostScript font names
  by setting the `postscriptFontName` attribute in Glyhps