### PR TITLE
fix FDKFeatureCompiler and --mti-source

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -183,7 +183,7 @@ def main(args=None):
         project.run_from_glyphs(glyphs_path, **args)
         return
 
-    exclude_args(parser, args, ['family_name'], 'Glyphs')
+    exclude_args(parser, args, ['family_name', 'mti_source'], 'Glyphs')
     if designspace_path:
         project.run_from_designspace(designspace_path, **args)
         return

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -110,12 +110,6 @@ def main(args=None):
         help='Interpolate layout tables from compiled master binaries. '
              'Requires Glyphs or MutatorMath source.')
     layoutGroup.add_argument(
-        '--use-afdko', action='store_true',
-        help='Use makeOTF instead of feaLib to compile FEA.')
-    layoutGroup.add_argument(
-        '--mti-source',
-        help='Path to mtiLib .txt feature definitions (use instead of FEA)')
-    layoutGroup.add_argument(
         '--kern-writer-module', metavar="MODULE", dest='kern_writer_class',
         type=PyClassType('KernFeatureWriter'),
         help='Module containing a custom `KernFeatureWriter` class.')
@@ -123,6 +117,13 @@ def main(args=None):
         '--mark-writer-module', metavar="MODULE", dest='mark_writer_class',
         type=PyClassType('MarkFeatureWriter'),
         help='Module containing a custom `MarkFeatureWriter` class.')
+    feaCompilerGroup = layoutGroup.add_mutually_exclusive_group(required=False)
+    feaCompilerGroup.add_argument(
+        '--use-afdko', action='store_true',
+        help='Use makeOTF instead of feaLib to compile FEA.')
+    feaCompilerGroup.add_argument(
+        '--mti-source',
+        help='Path to mtiLib .txt feature definitions (use instead of FEA)')
 
     glyphnamesGroup = parser.add_mutually_exclusive_group(required=False)
     glyphnamesGroup.add_argument(

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -76,13 +76,11 @@ class FontProject(object):
             glyphs_path, master_dir, designspace_instance_dir=instance_dir,
             family_name=family_name)
         if mti_source:
-            self.add_mti_features_to_master_ufos(
-                mti_source, designspace_path, masters)
+            self.add_mti_features_to_master_ufos(mti_source, masters)
         return designspace_path, instances
 
     @timer()
-    def add_mti_features_to_master_ufos(self, mti_source, designspace_path,
-                                        masters):
+    def add_mti_features_to_master_ufos(self, mti_source, masters):
         mti_dir = os.path.dirname(mti_source)
         with open(mti_source, 'rb') as mti_file:
             mti_paths = readPlist(mti_file)

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -241,9 +241,6 @@ class FontProject(object):
             ttf: If True, build fonts with TrueType outlines and .ttf extension.
             is_instance: If output fonts are instances, for generating paths.
             interpolatable: If output is interpolatable, for generating paths.
-            mti_source: Dictionary mapping postscript full names to dictionaries
-                mapping layout table tags to MTI source paths which should be
-                compiled into those tables.
             use_afdko: If True, use AFDKO to compile feature source.
             autohint: Parameters to provide to ttfautohint. If not provided, the
                 autohinting step is skipped.
@@ -360,19 +357,23 @@ class FontProject(object):
         subset.save_font(font, otf_path, opt)
 
     def run_from_glyphs(
-            self, glyphs_path, family_name=None, **kwargs):
+            self, glyphs_path, family_name=None, mti_source=None, **kwargs):
         """Run toolchain from Glyphs source.
 
         Args:
             glyphs_path: Path to source file.
             preprocess: If True, check source file for un-compilable content.
             family_name: If provided, uses this family name in the output.
+            mti_source: Path to property list file containing a dictionary
+                mapping UFO masters to dictionaries mapping layout table
+                tags to MTI source paths which should be compiled into
+                those tables.
             kwargs: Arguments passed along to run_from_designspace.
         """
 
         logger.info('Building master UFOs and designspace from Glyphs source')
         designspace_path, instance_data = self.build_master_ufos(
-            glyphs_path, family_name, mti_source=kwargs.get("mti_source"))
+            glyphs_path, family_name, mti_source=mti_source)
         self.run_from_designspace(
             designspace_path, instance_data=instance_data, **kwargs)
 
@@ -433,7 +434,7 @@ class FontProject(object):
             interpolate_layout_from=interpolate_layout_from, **kwargs)
 
     def run_from_ufos(
-            self, ufos, output=(), designspace_path=None, mti_source=None,
+            self, ufos, output=(), designspace_path=None,
             remove_overlaps=True, reverse_direction=True, conversion_error=None,
             **kwargs):
         """Run toolchain from UFO sources.
@@ -443,7 +444,6 @@ class FontProject(object):
             output: List of output formats to generate.
             designspace_path: Path to a MutatorMath designspace, used to
                 generate variable font if requested.
-            mti_source: MTI layout source to be parsed and passed to save_otfs.
             remove_overlaps: If True, remove overlaps in glyph shapes.
             reverse_direction: If True, reverse contour directions when
                 compiling TrueType outlines.

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -576,11 +576,13 @@ class FontProject(object):
 class FDKFeatureCompiler(FeatureCompiler):
     """An OTF compiler which uses the AFDKO to compile feature syntax."""
 
-    def setupFile_featureTables(self):
-        if self.mtiFeaFiles is not None:
-            super(FDKFeatureCompiler, self).setupFile_featureTables()
+    def __init__(self, *args, **kwargs):
+        super(FDKFeatureCompiler, self).__init__(*args, **kwargs)
+        if hasattr(self, 'mtiFeatures') and self.mtiFeatures is not None:
+            raise TypeError("MTI features not supported by makeotf")
 
-        elif not self.features.strip():
+    def setupFile_featureTables(self):
+        if not self.features.strip():
             return
 
         import subprocess

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fonttools==3.10.0
 cu2qu==1.1.1
-glyphsLib==1.7.0
+glyphsLib==1.7.2
 ufo2ft==0.5.0
 MutatorMath==2.0.4
 defcon==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools==3.10.0
+fonttools==3.11.0
 cu2qu==1.1.1
 glyphsLib==1.7.2
 ufo2ft==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ setup(
     install_requires=[
         "fonttools>=3.10.0",
         "cu2qu>=1.1.1",
-        "glyphsLib>=1.6.0",
+        "glyphsLib>=1.7.2",
         "ufo2ft>=0.5.0",
         "MutatorMath>=2.0.4",
         "defcon>=0.3.1",

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ setup(
     },
     setup_requires=wheel + bump2version,
     install_requires=[
-        "fonttools>=3.10.0",
+        "fonttools>=3.11.0",
         "cu2qu>=1.1.1",
         "glyphsLib>=1.7.2",
         "ufo2ft>=0.5.0",


### PR DESCRIPTION
- Fix AttributeError with new ufo2ft  FeatureCompiler (v0.5.0)
- make --use-afdko and --mti-source options mutually exclusive
- remove unused arguments and update some related docstrings