### PR TITLE
Use makeotf.cmd instead of makeotf on win32

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -586,6 +586,7 @@ class FDKFeatureCompiler(FeatureCompiler):
         if not self.features.strip():
             return
 
+        import sys
         import subprocess
         from fontTools.misc.py23 import tostr
 
@@ -602,7 +603,8 @@ class FDKFeatureCompiler(FeatureCompiler):
 
         report = tostr(subprocess.check_output([
             "makeotf", "-o", feasrc_path, "-f", outline_path,
-            "-ff", fea_path]))
+            "-ff", fea_path],
+            shell=True))
         os.remove(outline_path)
         os.remove(fea_path)
 


### PR DESCRIPTION
On Windows, running the command `makeotf` with subprocess.check_output fails with `FileNotFoundError: [WinError 2] The system cannot find the file specified`.