### PR TITLE
rename --no-round to --round-instances (positive), False by default

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -88,8 +88,8 @@ def main(args=None):
         '--family-name',
         help='Family name to use for masters, and to filter output instances')
     outputGroup.add_argument(
-        '--no-round', dest='no_round', action='store_true',
-        help='Do not round to integers in output when interpolating.')
+        '--round-instances', dest='round_instances', action='store_true',
+        help='Apply integer rounding to all geometry when interpolating')
 
     contourGroup = parser.add_argument_group(title='Handling of contours')
     contourGroup.add_argument(
@@ -193,7 +193,7 @@ def main(args=None):
 
     exclude_args(
         parser, args, ['interpolate', 'interpolate_binary_layout',
-                       'no_round'],
+                       'round_instances'],
         'Glyphs or MutatorMath')
     project.run_from_ufos(
         ufo_paths, is_instance=args.pop('masters_as_instances'), **args)

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -371,7 +371,7 @@ class FontProject(object):
     def run_from_designspace(
             self, designspace_path, interpolate=False,
             masters_as_instances=False, instance_data=None,
-            interpolate_binary_layout=False, no_round=False,
+            interpolate_binary_layout=False, round_instances=False,
             **kwargs):
         """Run toolchain from a MutatorMath design space document.
 
@@ -383,9 +383,8 @@ class FontProject(object):
                 glyphsLib's parsing function (ignored unless interpolate is True).
             interpolate_binary_layout: Interpolate layout tables from compiled
                 master binaries.
-            no_round: If True, don't use round geometry in MutatorMath,
-                thus allowing to re-use instances as masters without adding
-                rounding differences to other instances.
+            round_instances: apply integer rounding when interpolating with
+                MutatorMath.
             kwargs: Arguments passed along to run_from_ufos.
 
         Raises:
@@ -422,7 +421,7 @@ class FontProject(object):
                     shutil.rmtree(ipath)
             results = build_designspace(
                 designspace_path, outputUFOFormatVersion=3,
-                roundGeometry=not no_round)
+                roundGeometry=round_instances)
             if instance_data is not None:
                 ufos.extend(apply_instance_data(instance_data))
             else:


### PR DESCRIPTION
As discussed here:
https://github.com/googlei18n/ufo2ft/issues/192#issuecomment-355019434

by default we will now pass `roundGeometry=False` to MutatorMath, so the generated UFOs will have un-rounded float geometry. A new `--round-instances` option (replacing the [unreleased] `--no-round`) can be used to force integer geometry to the interpolated instance UFOs.

I called it `--round-instances` instead of simply `--round` to make it clear that this has nothing to do with the rounding that is specific to the output format (which occurs anyway but later on in the pipeline), but is only effective for interpolation of the intermediate instance sources.

The required integer rounding will be applied for us automatically by the fonttools pens (for coordinates), or by ufo2ft compiler for other fields that require integers.