### PR TITLE
add --output-path and --output-dir options

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -226,7 +226,8 @@ def main(args=None):
         project.run_from_ufos(
             ufo_paths, is_instance=args.pop('masters_as_instances'), **args)
     except FontmakeError as e:
-        parser.error(e)
+        import sys
+        sys.exit("fontmake: error: %s" % e)
 
 
 if __name__ == '__main__':

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -82,6 +82,15 @@ def main(args=None):
         help='Output font formats. Choose between: %(choices)s. '
              'Default: otf, ttf',
         choices=('ufo', 'otf', 'ttf', 'ttf-interpolatable', 'variable'))
+    outputSubGroup = outputGroup.add_mutually_exclusive_group()
+    outputSubGroup.add_argument(
+        '--output-path', default=None,
+        help="Output font file path. Only valid when the output is a single "
+        "file (e.g. input is a single UFO or output is variable font)")
+    outputSubGroup.add_argument(
+        '--output-dir', default=None,
+        help="Output folder. By default, output folders are created in the "
+        "current working directory, grouping output fonts by format.")
     outputGroup.add_argument(
         '-i', '--interpolate', nargs="?", default=False, const=True,
         metavar="INSTANCE_NAME",

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -130,7 +130,8 @@ def main(args=None):
 
     layoutGroup = parser.add_argument_group(title='Handling of OpenType Layout')
     layoutGroup.add_argument(
-        '--interpolate-binary-layout', action='store_true',
+        '--interpolate-binary-layout', nargs="?", default=False, const=True,
+        metavar="MASTER_DIR",
         help='Interpolate layout tables from compiled master binaries. '
              'Requires Glyphs or MutatorMath source.')
     layoutGroup.add_argument(

--- a/Lib/fontmake/errors.py
+++ b/Lib/fontmake/errors.py
@@ -2,3 +2,12 @@
 class FontmakeError(Exception):
     """Base class for all fontmake exceptions."""
     pass
+
+
+class TTFAError(FontmakeError):
+
+    def __init__(self, exitcode):
+        self.exitcode = exitcode
+
+    def __str__(self):
+        return "ttfautohint command failed: error " + str(self.exitcode)

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -584,6 +584,7 @@ class FontProject(object):
                 tempdirs.append(master_bin_dir)
             else:
                 output_dir = master_bin_dir = kwargs.pop("output_dir", None)
+            output_path = kwargs.pop("output_path", None)
             self.build_interpolatable_ttfs(
                 ufos, reverse_direction, conversion_error,
                 output_dir=master_bin_dir, **kwargs)
@@ -593,7 +594,7 @@ class FontProject(object):
                 raise TypeError('Need designspace to build variable font.')
             try:
                 self.build_variable_font(designspace_path,
-                                         output_path=kwargs.get("output_path"),
+                                         output_path=output_path,
                                          output_dir=output_dir,
                                          master_bin_dir=master_bin_dir)
             finally:

--- a/Lib/fontmake/ttfautohint.py
+++ b/Lib/fontmake/ttfautohint.py
@@ -15,6 +15,8 @@
 
 import subprocess
 
+from fontmake.errors import TTFAError
+
 
 def ttfautohint(in_file, out_file, args=None, **kwargs):
     """Thin wrapper around the ttfautohint command line tool.
@@ -29,7 +31,10 @@ def ttfautohint(in_file, out_file, args=None, **kwargs):
     if args is not None:
         if kwargs:
             raise TypeError('Should not provide both cmd args and kwargs.')
-        return subprocess.call(arg_list + args.split() + file_args)
+        rv = subprocess.call(arg_list + args.split() + file_args)
+        if rv != 0:
+            raise TTFAError(rv)
+        return
 
     boolean_options = (
         'debug', 'composites', 'dehint', 'help', 'ignore_restrictions',
@@ -53,4 +58,6 @@ def ttfautohint(in_file, out_file, args=None, **kwargs):
     if kwargs:
         raise TypeError('Unexpected argument(s): ' + ', '.join(kwargs.keys()))
 
-    return subprocess.call(arg_list + file_args)
+    rv = subprocess.call(arg_list + file_args)
+    if rv != 0:
+        raise TTFAError(rv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fonttools==3.25.0
-cu2qu==1.4.0
+cu2qu==1.5.0
 # I need to use glyphsLib master for
 # https://github.com/googlei18n/glyphsLib/pull/339
 # TODO: Remove this when glyphsLib is released with the above patch

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ setup(
     setup_requires=wheel + bump2version,
     install_requires=[
         "fonttools>=3.25.0",
-        "cu2qu>=1.3.0",
+        "cu2qu>=1.5.0",
         "glyphsLib>=2.2.1",
         "ufo2ft>=1.1.0",
         "MutatorMath>=2.1.0",


### PR DESCRIPTION
The two options are mutually exclusive.

`--output-path` can only be used when the output is a single file: e.g. when the input is a single UFO, or when only one instance was selected for export, or the source contains only one master, or the output format is a variable font.

The `--output-dir` option can be used with any binary output. The folder is created if it doesn't exist.

Finally, the `--interpolate-binary-layout` option now takes an optional parameter to customize the location of the binary masters used with `varLib.interpolate_layout` (e19f00f).

Fixes https://github.com/googlei18n/fontmake/issues/333 and https://github.com/googlei18n/fontmake/issues/396