### PR TITLE
optionally save master/instance ufos to temporary directory

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -429,7 +429,12 @@ class FontProject(object):
 
         Args:
             glyphs_path: Path to source file.
-            preprocess: If True, check source file for un-compilable content.
+            designspace_path: Output path of generated designspace document.
+                By default it's "<family_name>[-<base_style>].designspace".
+            master_dir: Directory where to save UFO masters (default:
+                "master_ufo").
+            instance_dir: Directory where to save UFO instances (default:
+                "instance_ufo").
             family_name: If provided, uses this family name in the output.
             mti_source: Path to property list file containing a dictionary
                 mapping UFO masters to dictionaries mapping layout table


### PR DESCRIPTION
In https://github.com/googlei18n/fontmake/pull/410#issuecomment-377329203, I added --master-dir and --instance-dir options to control where the glyphsLib-generated UFOs are created, and override the hardcoded "master_ufo"/"instance_ufo" directories.

Sometimes one may only be interested in running fontmake end-to-end from .glyphs sources to binary TTF or OTFs (or variable TTF), and thus the master_ufo and instance_ufo folders that are created in the current working directory are just unwanted leftovers.

This PR allows to pass to `--master-dir` or `--instance-dir` a special string `{tmp}`, which means create a temporary directory and use that, then clean it up automatically after finished.

I chose `{tmp}` because is short and it's unlikely that one wants to use it as the real name for an existing filesystem folder (giving the full path should work for those edge cases). 