### PR TITLE
subset_otf_from_ufo: Handle .notdef glyph

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -431,7 +431,13 @@ class FontProject(object):
                 os.remove(otf_path)
 
     def subset_otf_from_ufo(self, otf_path, ufo):
-        """Subset a font using export flags set by glyphsLib."""
+        """Subset a font using export flags set by glyphsLib.
+
+        There are two more settings that can change export behavior:
+        "Export Glyphs" and "Remove Glyphs", which are currently not supported
+        for complexity reasons. See
+        https://github.com/googlei18n/glyphsLib/issues/295.
+        """
         ufo_order = makeOfficialGlyphOrder(ufo)
         ot_order = TTFont(otf_path).getGlyphOrder()
         assert ot_order[0] == ".notdef"

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -438,15 +438,8 @@ class FontProject(object):
         include = []
         ufo_order = makeOfficialGlyphOrder(ufo)
         ot_order = TTFont(otf_path).getGlyphOrder()
-        assert ot_order[0] == ".notdef", (
-            "{}, subsetting: .notdef must be the first glyph in "
-            "{}.".format(ufo.path, otf_path)
-        )
-        assert len(ufo_order) == len(
-            ot_order
-        ), "{}, subsetting: amount of glyphs does not match with {}".format(
-            ufo.path, otf_path
-        )
+        assert ot_order[0] == ".notdef"
+        assert len(ufo_order) == len(ot_order)
 
         for old_name, new_name in zip(ufo_order, ot_order):
             glyph = ufo[old_name]

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -450,10 +450,10 @@ class FontProject(object):
 
         for old_name, new_name in zip(ufo_order, ot_order):
             glyph = ufo[old_name]
-            if ((keep_glyphs and old_name not in keep_glyphs) or
-                not glyph.lib.get(GLYPHS_PREFIX + 'Glyphs.Export', True)):
-                continue
-            include.append(new_name)
+            in_keep_glyphs = keep_glyphs and old_name not in keep_glyphs
+            exported = glyph.lib.get(GLYPHS_PREFIX + "Glyphs.Export", True)
+            if in_keep_glyphs or exported:
+                include.append(new_name)
 
         # copied from nototools.subset
         opt = subset.Options()

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -438,9 +438,19 @@ class FontProject(object):
         ufo_order = [glyph_name
                      for glyph_name in ufo.lib[PUBLIC_PREFIX + 'glyphOrder']
                      if glyph_name in ufo]
-        for old_name, new_name in zip(
-                ufo_order,
-                TTFont(otf_path).getGlyphOrder()):
+        ot_order = TTFont(otf_path).getGlyphOrder()
+
+        # An OpenType binary usually has the .notdef glyph as the first glyph,
+        # which might or might not be present in the UFO, and not necessarily as
+        # the first glyph. Manipulate the order to make glyph names match up in
+        # the loop below.
+        if ".notdef" in ufo:
+            ufo_order.pop(ufo_order.index(".notdef"))
+            ufo_order.insert(0, ".notdef")
+        else:
+            ot_order = ot_order[1:]  # Strip out ".notdef"
+
+        for old_name, new_name in zip(ufo_order, ot_order):
             glyph = ufo[old_name]
             if ((keep_glyphs and old_name not in keep_glyphs) or
                 not glyph.lib.get(GLYPHS_PREFIX + 'Glyphs.Export', True)):


### PR DESCRIPTION
The glyph names of UFO anf OT binary need to match up for the export flag testing to work. The .notdef glyph must be handled specially because it is usually the first glyph in the OT, but might not be present or in the first glyph slot in the UFO.

https://github.com/googlei18n/fontmake/issues/443

Now for some tests.