### PR TITLE
Optionally expand feature files to instance UFOs

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -186,6 +186,14 @@ def main(args=None):
         help="Enable ufoLib validation on reading/writing UFO files. It is "
         "disabled by default",
     )
+    outputGroup.add_argument(
+        "--expand-features-to-instances",
+        action="store_true",
+        help="Resolves all include()s in the master feature file and writes "
+        "the full feature file to all instance UFOs. Only valid when "
+        "interpolating. Use if you share feature files of masters in "
+        "external files, as instances can end up elsewhere.",
+    )
 
     contourGroup = parser.add_argument_group(title="Handling of contours")
     contourGroup.add_argument(

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/fontinfo.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/fontinfo.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>0</integer>
+	<key>capHeight</key>
+	<integer>0</integer>
+	<key>descender</key>
+	<integer>0</integer>
+	<key>familyName</key>
+	<string>Designspace Test</string>
+	<key>guidelines</key>
+	<array>
+	</array>
+	<key>postscriptBlueValues</key>
+	<array>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array>
+	</array>
+	<key>postscriptFamilyOtherBlues</key>
+	<array>
+	</array>
+	<key>postscriptOtherBlues</key>
+	<array>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+	</array>
+	<key>styleName</key>
+	<string>Light</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>xHeight</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/glyphs/contents.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/glyphs/layerinfo.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/layercontents.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/metainfo.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Light.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/features.fea
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/features.fea
@@ -1,0 +1,1 @@
+include(family.fea)

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/fontinfo.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/fontinfo.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>0</integer>
+	<key>capHeight</key>
+	<integer>0</integer>
+	<key>descender</key>
+	<integer>0</integer>
+	<key>familyName</key>
+	<string>Designspace Test</string>
+	<key>guidelines</key>
+	<array>
+	</array>
+	<key>postscriptBlueValues</key>
+	<array>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array>
+	</array>
+	<key>postscriptFamilyOtherBlues</key>
+	<array>
+	</array>
+	<key>postscriptOtherBlues</key>
+	<array>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+	</array>
+	<key>styleName</key>
+	<string>Regular</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>xHeight</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/glyphs/contents.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/glyphs/layerinfo.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/layercontents.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/metainfo.plist
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTest-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/test/DesignspaceTestSharedFeatures/DesignspaceTestSharedFeatures.designspace
+++ b/test/DesignspaceTestSharedFeatures/DesignspaceTestSharedFeatures.designspace
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="400" maximum="400" minimum="100" name="weight" tag="wght" />
+    </axes>
+    <sources>
+        <source familyname="Designspace Test" filename="DesignspaceTest-Light.ufo" name="Designspace Test Light" stylename="Light">
+            <location>
+                <dimension name="weight" xvalue="100.0" />
+            </location>
+        </source>
+        <source familyname="Designspace Test" filename="DesignspaceTest-Regular.ufo" name="Designspace Test Regular" stylename="Regular">
+            <groups copy="1" />
+            <features copy="1" />
+            <info copy="1" />
+            <lib copy="1" />
+            <location>
+                <dimension name="weight" xvalue="400.0" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+        <instance familyname="Designspace Test" filename="instance_ufo/DesignspaceTest-Light.ufo" name="Designspace Test Light" stylename="Light">
+            <location>
+                <dimension name="weight" xvalue="250.0" />
+            </location>
+            <info />
+            <kerning />
+        </instance>
+    </instances>
+</designspace>

--- a/test/run.sh
+++ b/test/run.sh
@@ -23,6 +23,7 @@ function check_failure() {
 }
 
 for src in 'DesignspaceTest' 'AvarDesignspaceTest'; do
+    echo "# Testing ${src} with interpolation"
     cd "${src}"
     mkdir -p instance_ufo
     fontmake -i -m "${src}.designspace"
@@ -30,8 +31,8 @@ for src in 'DesignspaceTest' 'AvarDesignspaceTest'; do
     cd ..
 done
 
-# also test the masters_as_instance parameter
 for src in 'DesignspaceTest' 'AvarDesignspaceTest'; do
+    echo "# Testing ${src} with interpolation and masters-as-instances"
     cd "${src}"
     mkdir -p instance_ufo
     fontmake -i -M -m "${src}.designspace"
@@ -39,7 +40,19 @@ for src in 'DesignspaceTest' 'AvarDesignspaceTest'; do
     cd ..
 done
 
+for src in 'DesignspaceTestSharedFeatures'; do
+    echo "# Testing ${src} with interpolation and master feature expansion"
+    cd "${src}"
+    mkdir -p instance_ufo
+    fontmake -i --expand-features-to-instances -m "${src}.designspace" -o ttf
+    check_failure "${src} failed to build"
+    grep -Fxq "# test" "instance_ufo/DesignspaceTest-Light.ufo/features.fea"
+    check_failure "${src} failed to build: no feature file in instance UFO"
+    cd ..
+done
+
 for src in 'InterpolateLayoutTest'; do
+    echo "# Testing ${src}"
     cd "${src}"
     fontmake -g "${src}.glyphs" --mti-source "${src}.plist" --no-production-names
     fontmake -g "${src}.glyphs" -i --interpolate-binary-layout --no-production-names
@@ -48,15 +61,19 @@ for src in 'InterpolateLayoutTest'; do
 done
 
 for src in 'GuidelineTest'; do
+    echo "# Testing ${src}"
     fontmake -i -g "${src}.glyphs"
     check_failure "${src} failed to build"
 done
 
+echo "# Testing subsetting with TestSubset.glyphs"
 fontmake -g TestSubset.glyphs -i "Test Subset Regular" -o ttf otf
 check_failure "TestSubset.glyphs failed to build"
 
+echo "# Running test_output.py"
 python test_output.py
 check_failure 'fontmake output incorrect'
 
+echo "# Running test_arguments.py"
 python test_arguments.py
 check_failure 'fontmake output incorrect'


### PR DESCRIPTION
I want to tackle #359.

Rather than changing the paths (complicated because you have to rewrite the AST recursively), here I just expand the feature file to every instance. Optional because Adobe's workflow apparently is to manage this manually.