### PR TITLE
Bump requirements for fontTools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,unicode,ufo]==3.37.0
+fonttools[lxml,unicode,ufo]==3.37.3
 cu2qu==1.6.5
 glyphsLib==3.2.0
 ufo2ft[pathops]==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     entry_points={"console_scripts": ["fontmake = fontmake.__main__:main"]},
     setup_requires=wheel + ["setuptools_scm"],
     install_requires=[
-        "fonttools[ufo,lxml,unicode]>=3.36.0",
+        "fonttools[ufo,lxml,unicode]>=3.37.3",
         "cu2qu>=1.6.5",
         "glyphsLib>=3.2.0b1",
         "ufo2ft>=2.7.0",


### PR DESCRIPTION
We need 3.37.1 for the MVAR generation fix.